### PR TITLE
Update map.jsp (QA-8871)

### DIFF
--- a/src/main/resources/jnt_map/html/map.jsp
+++ b/src/main/resources/jnt_map/html/map.jsp
@@ -14,7 +14,7 @@
 			<c:set var="mapKey" value="&amp;key=${locationMapKey}"/>
 		</c:if>
 	    <template:addResources type="javascript"
-							   resources="http://maps.google.com/maps/api/js?sensor=false&amp;language=${currentResource.locale.language}${mapKey}"/>
+							   resources="https://maps.google.com/maps/api/js?sensor=false&amp;language=${currentResource.locale.language}${mapKey}"/>
 	    <template:addResources type="javascript" resources="jquery.min.js"/>
 	    <template:addResources type="javascript" resources="jquery.jahia-googlemaps.js"/>
 	


### PR DESCRIPTION
Change the call to maps.google.com from HTTP to HTTPS because current version will not work on HTTPS generated pages (browser error).

Google recommends making all calls to maps.google.com in HTTPS anyway - https://developers.google.com/maps/documentation/javascript/tutorial#https-or-http
